### PR TITLE
Add CORS headers to HTTP response

### DIFF
--- a/tests/http_server.rs
+++ b/tests/http_server.rs
@@ -1,4 +1,5 @@
 use chrono::{TimeZone, Utc};
+use reqwest::header::HeaderValue;
 use reqwest::{Method, Response};
 use std::net::{SocketAddr, TcpListener};
 use std::str::FromStr;


### PR DESCRIPTION
While waiting for #1 and consequently routerify/routerify#107 this PR adds the appropriate CORS headers without using routerify.
