### PR TITLE
Fix unnecessary double reference

### DIFF
--- a/src/smtp.rs
+++ b/src/smtp.rs
@@ -273,7 +273,7 @@ impl SmtpServerImplementation {
             self.sender.clone()
         };
 
-        let message = parse_message(&sender, &self.recipients, &buf);
+        let message = parse_message(&sender, &self.recipients, buf);
         if message.is_err() {
             return Err(Box::new(message.err().unwrap()));
         }


### PR DESCRIPTION
Clippy moved `needless-borrow` from the nursery (disabled by default) to warnings, which now causes a CI failure. This PR fixes the unnecessary double reference.